### PR TITLE
Migrate Geo-by-IP to use geolite.info

### DIFF
--- a/src/geolocateNodes.js
+++ b/src/geolocateNodes.js
@@ -24,9 +24,10 @@ const upsert = async data => {
 const updateFromMaxmind = node => {
   const maxmind = config.get('maxmind');
 
-  const url = `https://'${maxmind.user}:${maxmind.key}@geoip.maxmind.com/geoip/v2.1/city/`;
+  const url = `https://${maxmind.user}:${maxmind.key}@geolite.info/geoip/v2.1/city/`; 
 
   return axios.get(`${url}${node.host}`)
+  .then(resp => resp.data)
   .then(resp => {
 
     const subdivision = resp.subdivisions ?
@@ -119,7 +120,7 @@ module.exports = () => {
       let query;
 
       if (node) {
-        query = config.maxmind ? updateFromMaxmind(node) : updateGeolocation(node);
+        query = config.get('maxmind') ? updateFromMaxmind(node) : updateGeolocation(node);
         return query.then(() => {
           return next();
         });


### PR DESCRIPTION
## High Level Overview of Change
Updates the `maxmind` URL to use the free service `geolite.info`

### Context of Change
Geo-location using `maxmind` originally used a different service, now uses the free `maxmind` service `geolite.info`, which gives up to 1000 queries per day, which should be enough for the current usage.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
Tested locally.
